### PR TITLE
Additional function interfaces in type.h and mpi.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.mod
 Makefile.conf
 config.h
+diff_version.sh
+

--- a/mpi.h
+++ b/mpi.h
@@ -438,4 +438,13 @@ extern int MPI_Type_ub(MPI_Datatype datatype, MPI_Aint * ub);
 
 extern double MPI_Wtime(void);
 
+
+
+/*
+ * Additional interfaces needed for compiling E3SM with gcc-14
+ */
+extern int MPI_Get_Version(int *mpi_vers, int *mpi_subvers);
+extern int MPI_Get_library_version(char *version, int *resultlen);
+extern int MPI_Info_free(MPI_Info *info);
+
 #endif

--- a/type.h
+++ b/type.h
@@ -122,4 +122,28 @@ extern int Unpack(void * inbuf, int insize, int * position, void *outbuf,
                   int outcount, Datatype type, Comm* comm);
 extern int Pack(void *inbuf, int incount, Datatype type,
               void *outbuf, int outsize, int *position, Comm * comm);
+
+// added to avoid implicit declaration error (GCC-14)
+extern int Copy_type(typepair *source, typepair *dest);
+extern int FGet_address(void * loc, long * address);
+extern int MPI_Address(void * loc, MPI_Aint * address);
+extern int MPI_Get_address(void * loc, MPI_Aint * address);
+extern int Pack_size(int incount, Datatype datatype,
+                   Comm * comm, MPI_Aint * size);
+extern int Type_contiguous(int count, Datatype oldtype, Datatype *newtype);
+extern int Type_create_indexed_block(int count, int blocklen, int *displacements,
+               Datatype oldtype, Datatype *newtype);
+extern int Type_hindexed(int count, int *blocklens, MPI_Aint *displacements,
+                  Datatype oldtype, Datatype *newtype);
+extern int Type_hvector(int count, int blocklen, MPI_Aint stride,
+                      Datatype oldtype, Datatype *newtype);
+extern int Type_indexed(int count, int *blocklens, int *displacements,
+                 Datatype oldtype, Datatype *newtype);
+extern int Type_lb(Datatype type, MPI_Aint * lb);
+extern int Type_size(Datatype type, int * size);
+extern int Type_struct(int count, int * blocklens, MPI_Aint * displacements,
+                Datatype *oldtypes_ptr,     Datatype *newtype);
+extern int Type_ub(Datatype type, MPI_Aint * ub);
+extern int Type_vector(int count, int blocklen, int stride,
+                Datatype oldtype, Datatype *newtype);
 #endif /* TYPE_H */


### PR DESCRIPTION
Added function interfaces to avoid lack of function declaration error. 

This solution avoids reordering functions in multiple c files. The lack of function declaration was triggering multiple error messages in gcc-14 (on a Macbook).
