### PR TITLE
Standardize mpi-serial MPI function prototypes with MPICH

### DIFF
--- a/cart.c
+++ b/cart.c
@@ -17,7 +17,7 @@ int FC_FUNC( mpi_cart_create , MPI_CART_CREATE )
 }
 
 
-int MPI_Cart_create( MPI_Comm comm_old, int ndims, int *dims, int *periods,
+int MPI_Cart_create( MPI_Comm comm_old, int ndims, const int dims[], const int periods[],
                      int reorder, MPI_Comm *comm_cart)
 {
   int i;
@@ -54,8 +54,8 @@ int FC_FUNC( mpi_cart_get , MPI_CART_GET )
 }
 
 
-int MPI_Cart_get(MPI_Comm comm, int maxdims, int *dims,
-                 int *periods, int *coords)
+int MPI_Cart_get(MPI_Comm comm, int maxdims, int dims[],
+                 int periods[], int coords[])
 {
   int i;
   for (i=0;i<maxdims;i++)
@@ -84,7 +84,7 @@ int FC_FUNC( mpi_cart_coords , MPI_CART_COORDS)
 }
 
 
-int MPI_Cart_coords(MPI_Comm comm, int rank, int maxdims, int *coords)
+int MPI_Cart_coords(MPI_Comm comm, int rank, int maxdims, int coords[])
 {
   int i;
 
@@ -116,7 +116,7 @@ int FC_FUNC( mpi_dims_create , MPI_DIMS_CREATE )
 }
 
 
-int MPI_Dims_create(int nnodes, int ndims, int *dims)
+int MPI_Dims_create(int nnodes, int ndims, int dims[])
 {
   int i;
 

--- a/collective.c
+++ b/collective.c
@@ -65,7 +65,7 @@ int FC_FUNC( mpi_gather , MPI_GATHER )
 }
 
 
-int MPI_Gather(void* sendbuf, int sendcount, MPI_Datatype sendtype,
+int MPI_Gather(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
 	       void* recvbuf, int recvcount, MPI_Datatype recvtype,
 	       int root, MPI_Comm comm)
 {
@@ -104,8 +104,8 @@ int FC_FUNC( mpi_gatherv , MPI_GATHERV )
 }
 
 
-int MPI_Gatherv(void* sendbuf, int sendcount, MPI_Datatype sendtype,
-		void* recvbuf, int *recvcounts, int *displs,
+int MPI_Gatherv(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
+		void* recvbuf, const int recvcounts[], const int displs[],
 		MPI_Datatype recvtype, int root, MPI_Comm comm)
 {
   int offset;
@@ -151,7 +151,7 @@ int FC_FUNC( mpi_allgather , MPI_ALLGATHER )
 }
 
 
-int MPI_Allgather(void* sendbuf, int sendcount, MPI_Datatype sendtype,
+int MPI_Allgather(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
 		  void* recvbuf, int recvcount, MPI_Datatype recvtype,
 		  MPI_Comm comm)
 {
@@ -182,8 +182,8 @@ int FC_FUNC( mpi_allgatherv , MPI_ALLGATHERV )
 }
 
 
-int MPI_Allgatherv(void* sendbuf, int sendcount, MPI_Datatype sendtype,
-		   void* recvbuf, int *recvcounts, int *displs,
+int MPI_Allgatherv(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
+		   void* recvbuf, const int recvcounts[], const int displs[],
                    MPI_Datatype recvtype, MPI_Comm comm)
 {
   int offset;
@@ -222,7 +222,7 @@ int FC_FUNC( mpi_scatter, MPI_SCATTER )
   return MPI_SUCCESS;
 }
 
-int MPI_Scatter(void * sendbuf, int sendcount, MPI_Datatype sendtype,
+int MPI_Scatter(const void * sendbuf, int sendcount, MPI_Datatype sendtype,
 		void * recvbuf, int recvcount, MPI_Datatype recvtype,
 		int root, MPI_Comm comm)
 {
@@ -262,7 +262,7 @@ int FC_FUNC( mpi_scatterv , MPI_SCATTERV )
 
 
 
-int MPI_Scatterv(void* sendbuf, int *sendcounts, int *displs,
+int MPI_Scatterv(const void* sendbuf, const int sendcounts[], const int displs[],
 		 MPI_Datatype sendtype, void* recvbuf, int recvcount,
 		 MPI_Datatype recvtype, int root, MPI_Comm comm)
 {
@@ -307,7 +307,7 @@ int FC_FUNC( mpi_reduce , MPI_REDUCE )
 
 
 
-int MPI_Reduce(void* sendbuf, void* recvbuf, int count,
+int MPI_Reduce(const void* sendbuf, void* recvbuf, int count,
 	       MPI_Datatype datatype, MPI_Op op, int root, MPI_Comm comm)
 
 {
@@ -338,7 +338,7 @@ int FC_FUNC( mpi_allreduce , MPI_ALLREDUCE )
 }
 
 
-int MPI_Allreduce(void* sendbuf, void* recvbuf, int count,
+int MPI_Allreduce(const void* sendbuf, void* recvbuf, int count,
 		  MPI_Datatype datatype, MPI_Op op, MPI_Comm comm)
 {
   if (sendbuf==MPI_IN_PLACE)
@@ -369,7 +369,7 @@ int FC_FUNC(mpi_reduce_scatter, MPI_REDUCE_SCATTER)
 }
 
 
-int MPI_Reduce_scatter(void* sendbuf, void* recvbuf, int *recvcounts,
+int MPI_Reduce_scatter(const void* sendbuf, void* recvbuf, const int recvcounts[],
                          MPI_Datatype datatype, MPI_Op op, MPI_Comm comm)
 {
   copy_data2(sendbuf, recvcounts[0], datatype, recvbuf, recvcounts[0], datatype);
@@ -392,7 +392,7 @@ int FC_FUNC( mpi_scan , MPI_SCAN)
 
 
 
-int MPI_Scan(void* sendbuf, void* recvbuf, int count,
+int MPI_Scan(const void* sendbuf, void* recvbuf, int count,
              MPI_Datatype datatype, MPI_Op op, MPI_Comm comm )
 {
     copy_data2(sendbuf, count, datatype, recvbuf, count, datatype);
@@ -415,7 +415,7 @@ int FC_FUNC( mpi_alltoall , MPI_ALLTOALL )
 }
 
 
-int MPI_Alltoall(void *sendbuf, int sendcount, MPI_Datatype sendtype,
+int MPI_Alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
 		 void *recvbuf, int recvcount, MPI_Datatype recvtype,
 		 MPI_Comm comm)
 {
@@ -442,10 +442,10 @@ int FC_FUNC( mpi_alltoallv , MPI_ALLTOALLV )
   return MPI_SUCCESS;
 }
 
-int MPI_Alltoallv(void *sendbuf, int *sendcounts,
-		  int *sdispls, MPI_Datatype sendtype,
-                  void *recvbuf, int *recvcounts,
-		  int *rdispls, MPI_Datatype recvtype,
+int MPI_Alltoallv(const void *sendbuf, const int sendcounts[],
+		  const int sdispls[], MPI_Datatype sendtype,
+                  void *recvbuf, const int recvcounts[],
+		  const int rdispls[], MPI_Datatype recvtype,
                   MPI_Comm comm)
 
 {
@@ -488,10 +488,10 @@ int FC_FUNC( mpi_alltoallw , MPI_ALLTOALLW )
 }
 
 
-int MPI_Alltoallw(void *sendbuf, int *sendcounts,
-		  int *sdispls, MPI_Datatype *sendtypes,
-                  void *recvbuf, int *recvcounts,
-		  int *rdispls, MPI_Datatype *recvtypes,
+int MPI_Alltoallw(const void *sendbuf, const int sendcounts[],
+		  const int sdispls[], const MPI_Datatype sendtypes[],
+                  void *recvbuf, const int recvcounts[],
+		  const int rdispls[], const MPI_Datatype recvtypes[],
                   MPI_Comm comm)
 
 {

--- a/copy.c
+++ b/copy.c
@@ -23,11 +23,11 @@
  * fix this issue later...
  */
 
-extern int Pcopy_data2(void *source, int src_count, Datatype src_type,
+extern int Pcopy_data2(const void *source, int src_count, Datatype src_type,
 		       void *dest, int dest_count, Datatype dest_type);
 
 
-int copy_data2(void *source, int src_count, MPI_Datatype src_type,
+int copy_data2(const void *source, int src_count, MPI_Datatype src_type,
                void *dest, int dest_count, MPI_Datatype dest_type)
 {
   Datatype src_ptr = *(Datatype*) mpi_handle_to_datatype(src_type);
@@ -39,7 +39,7 @@ int copy_data2(void *source, int src_count, MPI_Datatype src_type,
 
 
 
-int Pcopy_data2(void *source, int src_count, Datatype src_type,
+int Pcopy_data2(const void *source, int src_count, Datatype src_type,
                 void *dest, int dest_count, Datatype dest_type)
 {
   int i;

--- a/group.c
+++ b/group.c
@@ -13,7 +13,7 @@ int FC_FUNC( mpi_group_incl, MPI_GROUP_INCL )
 }
 
 
-int MPI_Group_incl(MPI_Group group, int n, int *ranks, MPI_Group *newgroup)
+int MPI_Group_incl(MPI_Group group, int n, const int ranks[], MPI_Group *newgroup)
 {
 
   if (group==MPI_GROUP_NULL)
@@ -211,7 +211,7 @@ int FC_FUNC( mpi_group_translate_ranks, MPI_GROUP_TRANSLATE_RANKS )
 
 
 
-int MPI_Group_translate_ranks(MPI_Group group1, int n, int *ranks1,
+int MPI_Group_translate_ranks(MPI_Group group1, int n, const int ranks1[],
 			      MPI_Group group2, int *ranks2)
 {
   int i;

--- a/info.c
+++ b/info.c
@@ -32,7 +32,7 @@ int FC_FUNC( mpi_info_set , MPI_INFO_SET ) (int *info, char *key, char *value, i
 }
 
 
-int MPI_Info_set(MPI_Info info, char *key, char *value)
+int MPI_Info_set(MPI_Info info, const char *key, const char *value)
 {
   /* for now, don't bother storing anything */
   return(MPI_SUCCESS);

--- a/mpi.c
+++ b/mpi.c
@@ -161,7 +161,7 @@ int MPI_Init_thread(int *argc, char **argv[], int required, int *provided)
     return MPI_Init(argc, argv);
 }
 
-int MPI_Init(int *argc, char **argv[])
+int MPI_Init(int *argc, char ***argv)
 {
   MPI_Comm my_comm_world;
 
@@ -333,10 +333,10 @@ void FC_FUNC( mpi_get_library_version, MPI_GET_LIBRARY_VERSION) (char *version, 
 
 
 
-int MPI_Get_Version(int *mpi_vers, int *mpi_subvers)
+int MPI_Get_Version(int *version, int *subversion)
 {
-    *mpi_vers = 1;
-    *mpi_subvers = 0;
+    *version = 1;
+    *subversion = 0;
 
     return (MPI_SUCCESS);
 }

--- a/mpi.h
+++ b/mpi.h
@@ -258,56 +258,56 @@ extern int MPI_Intercomm_create(MPI_Comm local_comm, int local_leader,
                           MPI_Comm peer_comm, int remote_leader,
                           int tag, MPI_Comm *newintercomm);
 extern int MPI_Intercomm_merge(MPI_Comm intercomm, int high,
-			       MPI_Comm *newintercomm);
-extern int MPI_Cart_create(MPI_Comm comm_old, int ndims, int *dims,
-                        int *periods, int reorder, MPI_Comm *comm_cart);
-extern int MPI_Cart_get(MPI_Comm comm, int maxdims, int *dims,
-                        int *periods, int *coords);
+                               MPI_Comm *newintracomm);
+extern int MPI_Cart_create(MPI_Comm comm_old, int ndims, const int dims[],
+                        const int periods[], int reorder, MPI_Comm *comm_cart);
+extern int MPI_Cart_get(MPI_Comm comm, int maxdims, int dims[],
+                        int periods[], int coords[]);
 extern int MPI_Cart_coords(MPI_Comm comm, int rank, int maxdims,
-                        int *coords);
-extern int MPI_Dims_create(int nnodes, int ndims, int *dims);
+                        int coords[]);
+extern int MPI_Dims_create(int nnodes, int ndims, int dims[]);
 
 extern int MPI_Barrier(MPI_Comm comm );
 extern int MPI_Bcast(void* buffer, int count, MPI_Datatype datatype,
                      int root, MPI_Comm comm );
-extern int MPI_Gather(void* sendbuf, int sendcount, MPI_Datatype sendtype,
+extern int MPI_Gather(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
                       void* recvbuf, int recvcount, MPI_Datatype recvtype,
                       int root, MPI_Comm comm);
-extern int MPI_Gatherv(void* sendbuf, int sendcount, MPI_Datatype sendtype,
-                       void* recvbuf, int *recvcounts, int *displs,
+extern int MPI_Gatherv(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
+                       void* recvbuf, const int recvcounts[], const int displs[],
                        MPI_Datatype recvtype, int root, MPI_Comm comm);
-extern int MPI_Allgather(void* sendbuf, int sendcount, MPI_Datatype sendtype,
+extern int MPI_Allgather(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
                          void* recvbuf, int recvcount, MPI_Datatype recvtype,
                          MPI_Comm comm);
-extern int MPI_Allgatherv(void* sendbuf, int sendcount, MPI_Datatype sendtype,
-                          void* recvbuf, int *recvcounts, int *displs,
+extern int MPI_Allgatherv(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
+                          void* recvbuf, const int recvcounts[], const int displs[],
                           MPI_Datatype recvtype, MPI_Comm comm);
-extern int MPI_Scatter( void* sendbuf, int sendcount, MPI_Datatype sendtype,
+extern int MPI_Scatter(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
                         void* recvbuf, int recvcount, MPI_Datatype recvtype,
                         int root, MPI_Comm comm);
-extern int MPI_Scatterv(void* sendbuf, int *sendcounts, int *displs,
+extern int MPI_Scatterv(const void* sendbuf, const int sendcounts[], const int displs[],
                         MPI_Datatype sendtype, void* recvbuf, int recvcount,
                         MPI_Datatype recvtype, int root, MPI_Comm comm);
-extern int MPI_Reduce(void* sendbuf, void* recvbuf, int count,
+extern int MPI_Reduce(const void* sendbuf, void* recvbuf, int count,
                       MPI_Datatype datatype, MPI_Op op, int root, MPI_Comm comm);
-extern int MPI_Reduce_scatter(void* sendbuf, void* recvbuf, int *recvcounts,
+extern int MPI_Reduce_scatter(const void* sendbuf, void* recvbuf, const int recvcounts[],
                          MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
-extern int MPI_Allreduce(void* sendbuf, void* recvbuf, int count,
+extern int MPI_Allreduce(const void* sendbuf, void* recvbuf, int count,
                          MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
-extern int MPI_Scan( void* sendbuf, void* recvbuf, int count,
+extern int MPI_Scan(const void* sendbuf, void* recvbuf, int count,
                     MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
-extern int MPI_Alltoall(void *sendbuf, int sendcount, MPI_Datatype sendtype,
+extern int MPI_Alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                         void *recvbuf, int recvcount, MPI_Datatype recvtype,
                         MPI_Comm comm);
-extern int MPI_Alltoallv(void *sendbuf, int *sendcounts,
-                         int *sdispls, MPI_Datatype sendtype,
-                         void *recvbuf, int *recvcounts,
-                         int *rdispls, MPI_Datatype recvtype,
+extern int MPI_Alltoallv(const void *sendbuf, const int sendcounts[],
+                         const int sdispls[], MPI_Datatype sendtype,
+                         void *recvbuf, const int recvcounts[],
+                         const int rdispls[], MPI_Datatype recvtype,
                          MPI_Comm comm) ;
-extern int MPI_Alltoallw(void *sendbuf, int *sendcounts,
-                         int *sdispls, MPI_Datatype *sendtypes,
-                         void *recvbuf, int *recvcounts,
-                         int *rdispls, MPI_Datatype *recvtypes,
+extern int MPI_Alltoallw(const void *sendbuf, const int sendcounts[],
+                         const int sdispls[], const MPI_Datatype sendtypes[],
+                         void *recvbuf, const int recvcounts[],
+                         const int rdispls[], const MPI_Datatype recvtypes[],
                          MPI_Comm comm) ;
 
 
@@ -326,7 +326,7 @@ extern int MPI_Comm_split(MPI_Comm comm, int color, int key, MPI_Comm *newcomm);
 extern int MPI_Comm_group(MPI_Comm comm, MPI_Group *group);
 extern MPI_Comm MPI_Comm_f2c(MPI_Fint comm);
 extern MPI_Fint MPI_Comm_c2f(MPI_Comm comm);
-extern int MPI_Group_incl(MPI_Group group, int n, int *ranks, MPI_Group *newgroup);
+extern int MPI_Group_incl(MPI_Group group, int n, const int ranks[], MPI_Group *newgroup);
 extern int MPI_Group_range_incl(MPI_Group group, int n, int ranges[][3],
                          MPI_Group *newgroup);
 extern int MPI_Group_union(MPI_Group group1, MPI_Group group2, MPI_Group *newgroup);
@@ -335,24 +335,24 @@ extern int MPI_Group_intersection(MPI_Group group1, MPI_Group group2,
 extern int MPI_Group_difference(MPI_Group group1, MPI_Group group2,
                          MPI_Group *newgroup);
 extern int MPI_Group_free(MPI_Group *group);
-extern int MPI_Group_translate_ranks(MPI_Group group1, int n, int *ranks1,
+extern int MPI_Group_translate_ranks(MPI_Group group1, int n, const int ranks1[],
                                      MPI_Group group2, int *ranks2);
 extern MPI_Group MPI_Group_f2c(MPI_Fint group);
 extern MPI_Fint MPI_Group_c2f(MPI_Group group);
 
-extern int MPI_Init(int *argc, char **argv[]) ;
+extern int MPI_Init(int *argc, char ***argv) ;
 extern int MPI_Finalize(void);
 extern int MPI_Abort(MPI_Comm comm, int errorcode);
 extern int MPI_Error_string(int errorcode, char *string, int *resultlen);
 extern int MPI_Get_processor_name(char *name, int *resultlen);
 
 extern int MPI_Info_create(MPI_Info *info);
-extern int MPI_Info_set(MPI_Info info, char *key, char *value);
+extern int MPI_Info_set(MPI_Info info, const char *key, const char *value);
 
 extern int MPI_Initialized(int *flag);
-extern int MPI_Pack( void *inbuf, int incount, MPI_Datatype datatype,
+extern int MPI_Pack(const void *inbuf, int incount, MPI_Datatype datatype,
                      void *outbuf, int outsize, int *position, MPI_Comm comm);
-extern int MPI_Unpack( void *inbuf, int insize, int *position,
+extern int MPI_Unpack(const void *inbuf, int insize, int *position,
                        void *outbuf, int outcount, MPI_Datatype datatype,
                        MPI_Comm comm );
 extern int MPI_Irecv(void *buf, int count, MPI_Datatype datatype,
@@ -362,34 +362,34 @@ extern int MPI_Recv(void *buf, int count, MPI_Datatype datatype, int source,
 
 extern int MPI_Test(MPI_Request *request, int *flag, MPI_Status *status);
 extern int MPI_Wait(MPI_Request *request, MPI_Status *status);
-extern int MPI_Testany(int count,  MPI_Request *array_of_requests,
+extern int MPI_Testany(int count,  MPI_Request array_of_requests[],
                        int *index, int *flag, MPI_Status *status);
-extern int MPI_Waitany(int count, MPI_Request *array_of_requests,
+extern int MPI_Waitany(int count, MPI_Request array_of_requests[],
                        int *index, MPI_Status *status);
-extern int MPI_Testall(int count, MPI_Request *array_of_requests,
+extern int MPI_Testall(int count, MPI_Request array_of_requests[],
                        int *flag, MPI_Status *array_of_statuses);
-extern int MPI_Waitall(int count, MPI_Request *array_of_requests,
+extern int MPI_Waitall(int count, MPI_Request array_of_requests[],
                        MPI_Status *array_of_statuses);
 extern MPI_Request MPI_Request_f2c(MPI_Fint request);
 extern MPI_Fint MPI_Request_c2f(MPI_Request request);
-extern int MPI_Testsome(int incount, MPI_Request *array_of_requests,
-                        int *outcount, int *array_of_indices,
+extern int MPI_Testsome(int incount, MPI_Request array_of_requests[],
+                        int *outcount, int array_of_indices[],
                         MPI_Status *array_of_statuses);
-extern int MPI_Waitsome(int incount, MPI_Request *array_of_requests,
-                        int *outcount, int *array_of_indices,
+extern int MPI_Waitsome(int incount, MPI_Request array_of_requests[],
+                        int *outcount, int array_of_indices[],
                         MPI_Status *array_of_statuses);
 extern int MPI_Request_free(MPI_Request * req);
-extern int MPI_Isend(void *buf, int count, MPI_Datatype datatype,
+extern int MPI_Isend(const void *buf, int count, MPI_Datatype datatype,
                      int dest, int tag, MPI_Comm comm, MPI_Request *request) ;
-extern int MPI_Send(void* buf, int count, MPI_Datatype datatype,
+extern int MPI_Send(const void* buf, int count, MPI_Datatype datatype,
                     int dest, int tag, MPI_Comm comm);
-extern int MPI_Ssend(void* buf, int count, MPI_Datatype datatype,
+extern int MPI_Ssend(const void* buf, int count, MPI_Datatype datatype,
                      int dest, int tag, MPI_Comm comm);
-extern int MPI_Rsend(void* buf, int count, MPI_Datatype datatype,
+extern int MPI_Rsend(const void* buf, int count, MPI_Datatype datatype,
                      int dest, int tag, MPI_Comm comm);
-extern int MPI_Irsend(void *buf, int count, MPI_Datatype datatype,
+extern int MPI_Irsend(const void *buf, int count, MPI_Datatype datatype,
                      int dest, int tag, MPI_Comm comm, MPI_Request *request) ;
-extern int MPI_Sendrecv(void* sendbuf, int sendcount, MPI_Datatype sendtype,
+extern int MPI_Sendrecv(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
                         int dest, int sendtag,
                         void *recvbuf, int recvcount, MPI_Datatype recvtype,
                         int source, int recvtag,
@@ -409,32 +409,32 @@ extern int MPI_Get_count(MPI_Status *status, MPI_Datatype datatype, int *count);
 extern int MPI_Get_elements(MPI_Status *status, MPI_Datatype datatype, int *count);
 extern int MPI_Type_contiguous(int count, MPI_Datatype oldtype, MPI_Datatype *newtype);
 
-extern int MPI_Type_vector(int count, int blocklen, int stride, MPI_Datatype oldtype,
+extern int MPI_Type_vector(int count, int blocklength, int stride, MPI_Datatype oldtype,
                            MPI_Datatype *newtype);
 
-extern int MPI_Type_hvector(int count, int blocklen, MPI_Aint stride,
+extern int MPI_Type_hvector(int count, int blocklength, MPI_Aint stride,
                             MPI_Datatype oldtype, MPI_Datatype *newtype);
 
-extern int MPI_Type_create_hvector(int count, int blocklen, MPI_Aint stride,
+extern int MPI_Type_create_hvector(int count, int blocklength, MPI_Aint stride,
                             MPI_Datatype oldtype, MPI_Datatype *newtype);
 
-extern int MPI_Type_indexed(int count, int *blocklens, int *displacements,
+extern int MPI_Type_indexed(int count, const int array_of_blocklengths[], const int array_of_displacements[],
                             MPI_Datatype oldtype, MPI_Datatype *newtype);
 
-extern int MPI_Type_create_indexed_block(int count, int blocklen, int *displacements,
+extern int MPI_Type_create_indexed_block(int count, int blocklength, const int array_of_displacements[],
                                   MPI_Datatype oldtype, MPI_Datatype *newtype);
-extern int MPI_Type_hindexed(int count, int *blocklens, MPI_Aint *displacements,
+extern int MPI_Type_hindexed(int count, int array_of_blocklengths[], MPI_Aint array_of_displacements[],
                              MPI_Datatype oldtype, MPI_Datatype *newtype);
 extern int MPI_Type_size(MPI_Datatype type, int * size);
-extern int MPI_Type_struct(int count, int *blocklens, MPI_Aint *displacements,
-                           MPI_Datatype *oldtypes, MPI_Datatype *newtype);
+extern int MPI_Type_struct(int count, int array_of_blocklengths[], MPI_Aint array_of_displacements[],
+                           MPI_Datatype array_of_types[], MPI_Datatype *newtype);
 extern int MPI_Type_dup(MPI_Datatype oldtype, MPI_Datatype *newtype);
 
 extern int MPI_Type_extent(MPI_Datatype datatype, MPI_Aint * extent);
 extern int MPI_Type_commit(MPI_Datatype * datatype);
 extern int MPI_Type_free(MPI_Datatype * datatype);
-extern int MPI_Type_lb(MPI_Datatype datatype, MPI_Aint * lb);
-extern int MPI_Type_ub(MPI_Datatype datatype, MPI_Aint * ub);
+extern int MPI_Type_lb(MPI_Datatype datatype, MPI_Aint *displacement);
+extern int MPI_Type_ub(MPI_Datatype datatype, MPI_Aint *displacement);
 
 extern double MPI_Wtime(void);
 
@@ -443,8 +443,7 @@ extern double MPI_Wtime(void);
 /*
  * Additional interfaces needed for compiling E3SM with gcc-14
  */
-extern int MPI_Get_Version(int *mpi_vers, int *mpi_subvers);
-extern int MPI_Get_library_version(char *version, int *resultlen);
+extern int MPI_Get_Version(int *version, int *subversion);
 extern int MPI_Info_free(MPI_Info *info);
 
 #endif

--- a/mpiP.h
+++ b/mpiP.h
@@ -106,7 +106,7 @@ typedef struct
 /****************************************************************************/
 
 /* copy functions */
-extern int copy_data2(void * source, int src_count, MPI_Datatype src_type,
+extern int copy_data2(const void * source, int src_count, MPI_Datatype src_type,
                       void * dest, int dest_count, MPI_Datatype dest_type);
 
 extern void *mpi_malloc(int size);

--- a/mpiP.h
+++ b/mpiP.h
@@ -94,7 +94,7 @@ typedef struct
 {
   pListitem listitem;        /* to allow Req to be removed from list */
 
-  int *buf;
+  void *buf;
   int source;
   int tag;
   int complete;

--- a/pack.c
+++ b/pack.c
@@ -20,7 +20,7 @@ int FC_FUNC( mpi_pack , MPI_PACK )
 
 
 
-int MPI_Pack( void *inbuf, int incount, MPI_Datatype datatype,
+int MPI_Pack(const void *inbuf, int incount, MPI_Datatype datatype,
               void *outbuf, int outsize, int *position, MPI_Comm comm)
 {
   int ret;
@@ -35,7 +35,7 @@ int MPI_Pack( void *inbuf, int incount, MPI_Datatype datatype,
 
 
 
-int Pack(void *inbuf, int incount, Datatype type,
+int Pack(const void *inbuf, int incount, Datatype type,
               void *outbuf, int outsize, int *position, Comm * comm)
 {
   int i, j;
@@ -111,7 +111,7 @@ int FC_FUNC( mpi_unpack , MPI_UNPACK )
 }
 
 
-int MPI_Unpack(void * inbuf, int insize, int * position, void * outbuf,
+int MPI_Unpack(const void * inbuf, int insize, int * position, void * outbuf,
                int outcount, MPI_Datatype type, MPI_Comm comm)
 {
   int ret;
@@ -123,7 +123,7 @@ int MPI_Unpack(void * inbuf, int insize, int * position, void * outbuf,
   return ret;
 }
 
-int Unpack(void * inbuf, int insize, int * position, void *outbuf,
+int Unpack(const void * inbuf, int insize, int * position, void *outbuf,
                 int outcount, Datatype type, Comm* comm)
 {
   int i, j;

--- a/recv.c
+++ b/recv.c
@@ -93,7 +93,7 @@ int MPI_Irecv(void *buf, int count, MPI_Datatype datatype,
       return(MPI_SUCCESS);
     }
 
-  rreq->buf=(int*)buf;
+  rreq->buf=buf;
   rreq->tag=tag;
   rreq->complete=0;
   rreq->listitem=AP_list_append(mycomm->recvlist,rreq);

--- a/recv.c
+++ b/recv.c
@@ -93,7 +93,7 @@ int MPI_Irecv(void *buf, int count, MPI_Datatype datatype,
       return(MPI_SUCCESS);
     }
 
-  rreq->buf=buf;
+  rreq->buf=(int*)buf;
   rreq->tag=tag;
   rreq->complete=0;
   rreq->listitem=AP_list_append(mycomm->recvlist,rreq);

--- a/req.c
+++ b/req.c
@@ -90,7 +90,7 @@ int FC_FUNC( mpi_waitany , MPI_WAITANY )(int *count, int *requests,
 
 
 
-int MPI_Waitany(int count, MPI_Request *array_of_requests,
+int MPI_Waitany(int count, MPI_Request array_of_requests[],
                 int *index, MPI_Status *status)
 {
   int flag;
@@ -123,7 +123,7 @@ int FC_FUNC(mpi_testany, MPI_TESTANY)
   return MPI_SUCCESS;
 }
 
-int MPI_Testany(int count,  MPI_Request *array_of_requests,
+int MPI_Testany(int count,  MPI_Request array_of_requests[],
                 int *index, int *flag, MPI_Status *status)
 {
   int i;
@@ -155,7 +155,7 @@ int FC_FUNC(mpi_testall, MPI_TESTALL)
   return MPI_SUCCESS;
 }
 
-int MPI_Testall(int count, MPI_Request *array_of_requests,
+int MPI_Testall(int count, MPI_Request array_of_requests[],
                 int *flag, MPI_Status *array_of_statuses)
 {
   int i;
@@ -190,7 +190,7 @@ int FC_FUNC( mpi_waitall , MPI_WAITALL )(int *count, int *array_of_requests,
 
 
 
-int MPI_Waitall(int count, MPI_Request *array_of_requests,
+int MPI_Waitall(int count, MPI_Request array_of_requests[],
                 MPI_Status *array_of_statuses)
 {
   int i;
@@ -223,8 +223,8 @@ int FC_FUNC(mpi_testsome, MPI_TESTSOME)
   return MPI_SUCCESS;
 }
 
-int MPI_Testsome(int incount, MPI_Request *array_of_requests, int *outcount,
-                 int *array_of_indices, MPI_Status *array_of_statuses)
+int MPI_Testsome(int incount, MPI_Request array_of_requests[], int *outcount,
+                 int array_of_indices[], MPI_Status *array_of_statuses)
 {
   int i;
   int flag;
@@ -256,8 +256,8 @@ int FC_FUNC(mpi_waitsome, MPI_WAITSOME)
   return MPI_SUCCESS;
 }
 
-int MPI_Waitsome(int incount, MPI_Request *array_of_requests, int *outcount,
-                 int *array_of_indices, MPI_Status *array_of_statuses)
+int MPI_Waitsome(int incount, MPI_Request array_of_requests[], int *outcount,
+                 int array_of_indices[], MPI_Status *array_of_statuses)
 {
   MPI_Testsome(incount, array_of_requests, outcount,
                array_of_indices, array_of_statuses);

--- a/send.c
+++ b/send.c
@@ -82,7 +82,7 @@ int MPI_Isend(const void *buf, int count, MPI_Datatype datatype,
       return(MPI_SUCCESS);
     }
 
-  sreq->buf=(int*)buf;
+  sreq->buf=(void*)buf; /* Explicit cast to suppress discarded-qualifiers warning */
   sreq->tag=tag;
   sreq->complete=0;
   sreq->listitem=AP_list_append(mycomm->sendlist,sreq);

--- a/send.c
+++ b/send.c
@@ -33,7 +33,7 @@ int FC_FUNC( mpi_isend , MPI_ISEND )(void *buf, int *count, int *datatype,
 
 
 
-int MPI_Isend(void *buf, int count, MPI_Datatype datatype,
+int MPI_Isend(const void *buf, int count, MPI_Datatype datatype,
 	      int dest, int tag, MPI_Comm comm, MPI_Request *request)
 {
   pListitem match;
@@ -82,7 +82,7 @@ int MPI_Isend(void *buf, int count, MPI_Datatype datatype,
       return(MPI_SUCCESS);
     }
 
-  sreq->buf=buf;
+  sreq->buf=(int*)buf;
   sreq->tag=tag;
   sreq->complete=0;
   sreq->listitem=AP_list_append(mycomm->sendlist,sreq);
@@ -107,7 +107,7 @@ int FC_FUNC(mpi_send, MPI_SEND) ( void *buf, int *count, int *datatype,
 
 
 
-int MPI_Send(void* buf, int count, MPI_Datatype datatype,
+int MPI_Send(const void* buf, int count, MPI_Datatype datatype,
 	     int dest, int tag, MPI_Comm comm)
 {
   MPI_Request request;
@@ -140,7 +140,7 @@ int FC_FUNC(mpi_ssend, MPI_SSEND) ( void *buf, int *count, int *datatype,
 
 
 
-int MPI_Ssend(void* buf, int count, MPI_Datatype datatype,
+int MPI_Ssend(const void* buf, int count, MPI_Datatype datatype,
               int dest, int tag, MPI_Comm comm)
 {
   return(MPI_Send(buf,count,datatype,dest,tag,comm));
@@ -160,7 +160,7 @@ int FC_FUNC(mpi_rsend, MPI_RSEND) ( void *buf, int *count, int *datatype,
 
 
 
-int MPI_Rsend(void* buf, int count, MPI_Datatype datatype,
+int MPI_Rsend(const void* buf, int count, MPI_Datatype datatype,
               int dest, int tag, MPI_Comm comm)
 {
   return(MPI_Send(buf,count,datatype,dest,tag,comm));
@@ -185,7 +185,7 @@ int FC_FUNC( mpi_irsend , MPI_IRSEND )(void *buf, int *count, int *datatype,
 
 
 
-int MPI_Irsend(void *buf, int count, MPI_Datatype datatype,
+int MPI_Irsend(const void *buf, int count, MPI_Datatype datatype,
                int dest, int tag, MPI_Comm comm, MPI_Request *request)
 {
   Req *req;
@@ -230,7 +230,7 @@ int FC_FUNC(mpi_sendrecv, MPI_SENDRECV) (
 
 
 
-int MPI_Sendrecv(void* sendbuf, int sendcount, MPI_Datatype sendtype,
+int MPI_Sendrecv(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
                  int dest, int sendtag,
                  void *recvbuf, int recvcount, MPI_Datatype recvtype,
                  int source, int recvtag,

--- a/type.c
+++ b/type.c
@@ -256,7 +256,7 @@ int Copy_type(typepair *source, typepair *dest)
  * All other type constructors call this function.
  */
 
-int Type_struct(int count, int * blocklens, MPI_Aint * displacements,
+int Type_struct(int count, const int * blocklens, const MPI_Aint * displacements,
                 Datatype *oldtypes_ptr,     Datatype *newtype)
 {
   int i, j, k;
@@ -400,8 +400,8 @@ int FC_FUNC( mpi_type_struct, MPI_TYPE_STRUCT )
 /* Public function, wrapper for Type_struct that translates handle to
  * pointer (see NOTES at top of file)
  */
-int MPI_Type_struct(int count, int * blocklens, MPI_Aint * displacements,
-                    MPI_Datatype *oldtypes,     MPI_Datatype *newtype)
+int MPI_Type_struct(int count, int array_of_blocklengths[], MPI_Aint array_of_displacements[],
+                    MPI_Datatype array_of_types[],     MPI_Datatype *newtype)
 {
     int i;
     Datatype oldtypes_ptr[count];
@@ -409,12 +409,12 @@ int MPI_Type_struct(int count, int * blocklens, MPI_Aint * displacements,
 
     for (i = 0; i < count; i++)
     {
-        oldtypes_ptr[i] = *(Datatype*) mpi_handle_to_datatype(oldtypes[i]);
+        oldtypes_ptr[i] = *(Datatype*) mpi_handle_to_datatype(array_of_types[i]);
     }
 
     mpi_alloc_handle(newtype, (void**) &newtype_ptr);
 
-    return Type_struct(count, blocklens, displacements,
+    return Type_struct(count, array_of_blocklengths, array_of_displacements,
                        oldtypes_ptr, newtype_ptr);
 }
 
@@ -491,14 +491,14 @@ int FC_FUNC( mpi_type_hvector, MPI_TYPE_HVECTOR )
   return MPI_SUCCESS;
 }
 
-int MPI_Type_hvector(int count, int blocklen, MPI_Aint stride,
+int MPI_Type_hvector(int count, int blocklength, MPI_Aint stride,
                      MPI_Datatype oldtype, MPI_Datatype * newtype)
 {
   Datatype old_ptr = *(Datatype*) mpi_handle_to_datatype(oldtype);
   Datatype * new_ptr;
 
   mpi_alloc_handle(newtype, (void**) &new_ptr);
-  return Type_hvector(count, blocklen, stride, old_ptr, new_ptr);
+  return Type_hvector(count, blocklength, stride, old_ptr, new_ptr);
 }
 
 int FC_FUNC( mpi_type_create_hvector, MPI_TYPE_CREATE_HVECTOR )
@@ -509,14 +509,14 @@ int FC_FUNC( mpi_type_create_hvector, MPI_TYPE_CREATE_HVECTOR )
   return MPI_SUCCESS;
 }
 
-int MPI_Type_create_hvector(int count, int blocklen, MPI_Aint stride,
+int MPI_Type_create_hvector(int count, int blocklength, MPI_Aint stride,
                      MPI_Datatype oldtype, MPI_Datatype * newtype)
 {
   Datatype old_ptr = *(Datatype*) mpi_handle_to_datatype(oldtype);
   Datatype * new_ptr;
 
   mpi_alloc_handle(newtype, (void**) &new_ptr);
-  return Type_hvector(count, blocklen, stride, old_ptr, new_ptr);
+  return Type_hvector(count, blocklength, stride, old_ptr, new_ptr);
 }
 
 
@@ -545,7 +545,7 @@ int FC_FUNC( mpi_type_vector, MPI_TYPE_VECTOR )
 
 }
 
-int MPI_Type_vector(int count, int blocklen, int stride,
+int MPI_Type_vector(int count, int blocklength, int stride,
                     MPI_Datatype oldtype, MPI_Datatype * newtype)
 {
   Datatype old_ptr = *(Datatype*) mpi_handle_to_datatype(oldtype);
@@ -553,13 +553,13 @@ int MPI_Type_vector(int count, int blocklen, int stride,
 
   mpi_alloc_handle(newtype, (void**) &new_ptr);
 
-  return Type_vector(count, blocklen, stride, old_ptr, new_ptr);
+  return Type_vector(count, blocklength, stride, old_ptr, new_ptr);
 }
 
 
 /*******************************************************/
 
-int Type_hindexed(int count, int *blocklens, MPI_Aint *displacements,
+int Type_hindexed(int count, const int *blocklens, const MPI_Aint *displacements,
                   Datatype oldtype, Datatype *newtype)
 {
     int i;
@@ -582,20 +582,20 @@ int FC_FUNC( mpi_type_hindexed, MPI_TYPE_HINDEXED )
   return MPI_SUCCESS;
 }
 
-int MPI_Type_hindexed(int count, int *blocklens, MPI_Aint * disps,
+int MPI_Type_hindexed(int count, int array_of_blocklengths[], MPI_Aint array_of_displacements[],
                       MPI_Datatype oldtype, MPI_Datatype * newtype)
 {
   Datatype old_ptr = *(Datatype*) mpi_handle_to_datatype(oldtype);
   Datatype * new_ptr;
 
   mpi_alloc_handle(newtype, (void**) &new_ptr);
-  return Type_hindexed(count, blocklens, disps, old_ptr, new_ptr);
+  return Type_hindexed(count, array_of_blocklengths, array_of_displacements, old_ptr, new_ptr);
 }
 
 
 /*******************************************************/
 
-int Type_indexed(int count, int *blocklens, int *displacements,
+int Type_indexed(int count, const int *blocklens, const int *displacements,
                  Datatype oldtype, Datatype *newtype)
 {
     int i;
@@ -620,19 +620,19 @@ int FC_FUNC( mpi_type_indexed, MPI_TYPE_INDEXED )
 }
 
 
-int MPI_Type_indexed(int count, int *blocklens, int *displacements,
+int MPI_Type_indexed(int count, const int array_of_blocklengths[], const int array_of_displacements[],
                      MPI_Datatype oldtype, MPI_Datatype * newtype)
 {
   Datatype old_ptr = *(Datatype*) mpi_handle_to_datatype(oldtype);
   Datatype * new_ptr;
 
   mpi_alloc_handle(newtype, (void**) &new_ptr);
-  return Type_indexed(count, blocklens, displacements, old_ptr, new_ptr);
+  return Type_indexed(count, array_of_blocklengths, array_of_displacements, old_ptr, new_ptr);
 }
 
 /*******************************************************/
 
-int Type_create_indexed_block(int count, int blocklen, int *displacements,
+int Type_create_indexed_block(int count, int blocklen, const int *displacements,
 			      Datatype oldtype, Datatype *newtype)
 {
     int i;
@@ -653,14 +653,14 @@ int FC_FUNC( mpi_type_create_indexed_block, MPI_TYPE_CREATE_INDEXED_BLOCK )
   return MPI_SUCCESS;
 }
 
-int MPI_Type_create_indexed_block(int count, int blocklen, int *displacements,
+int MPI_Type_create_indexed_block(int count, int blocklength, const int array_of_displacements[],
 				  MPI_Datatype oldtype, MPI_Datatype * newtype)
 {
   Datatype old_ptr = *(Datatype*) mpi_handle_to_datatype(oldtype);
   Datatype * new_ptr;
 
   mpi_alloc_handle(newtype, (void**) &new_ptr);
-  return Type_create_indexed_block(count, blocklen, displacements, old_ptr, new_ptr);
+  return Type_create_indexed_block(count, blocklength, array_of_displacements, old_ptr, new_ptr);
 }
 
 /*******************************************************/
@@ -725,11 +725,11 @@ int FC_FUNC( mpi_type_lb, MPI_TYPE_LB )(int * type, MPI_Aint * lb, int * ierr)
   return MPI_SUCCESS;
 }
 
-int MPI_Type_lb(MPI_Datatype type, MPI_Aint * lb)
+int MPI_Type_lb(MPI_Datatype type, MPI_Aint *displacement)
 {
   Datatype type_ptr = *(Datatype*) mpi_handle_to_datatype(type);
 
-  return Type_lb(type_ptr, lb);
+  return Type_lb(type_ptr, displacement);
 }
 
 /* MPI_Type_ub: Return upper bound (which may be overridden
@@ -747,11 +747,11 @@ int FC_FUNC( mpi_type_ub, MPI_TYPE_UB )(int * type, MPI_Aint * ub, int * ierr)
   return MPI_SUCCESS;
 }
 
-int MPI_Type_ub(MPI_Datatype type, MPI_Aint * ub)
+int MPI_Type_ub(MPI_Datatype type, MPI_Aint *displacement)
 {
   Datatype type_ptr = *(Datatype*) mpi_handle_to_datatype(type);
 
-  return Type_ub(type_ptr, ub);
+  return Type_ub(type_ptr, displacement);
 }
 
 /* MPI_Get_address

--- a/type.h
+++ b/type.h
@@ -118,9 +118,9 @@ int print_typemap(MPI_Datatype in);
 const extern Datatype simpletypes[];
 Datatype* mpi_handle_to_datatype(int handle);
 
-extern int Unpack(void * inbuf, int insize, int * position, void *outbuf,
+extern int Unpack(const void * inbuf, int insize, int * position, void *outbuf,
                   int outcount, Datatype type, Comm* comm);
-extern int Pack(void *inbuf, int incount, Datatype type,
+extern int Pack(const void *inbuf, int incount, Datatype type,
               void *outbuf, int outsize, int *position, Comm * comm);
 
 // added to avoid implicit declaration error (GCC-14)
@@ -131,17 +131,17 @@ extern int MPI_Get_address(void * loc, MPI_Aint * address);
 extern int Pack_size(int incount, Datatype datatype,
                    Comm * comm, MPI_Aint * size);
 extern int Type_contiguous(int count, Datatype oldtype, Datatype *newtype);
-extern int Type_create_indexed_block(int count, int blocklen, int *displacements,
+extern int Type_create_indexed_block(int count, int blocklen, const int *displacements,
                Datatype oldtype, Datatype *newtype);
-extern int Type_hindexed(int count, int *blocklens, MPI_Aint *displacements,
+extern int Type_hindexed(int count, const int *blocklens, const MPI_Aint *displacements,
                   Datatype oldtype, Datatype *newtype);
 extern int Type_hvector(int count, int blocklen, MPI_Aint stride,
                       Datatype oldtype, Datatype *newtype);
-extern int Type_indexed(int count, int *blocklens, int *displacements,
+extern int Type_indexed(int count, const int *blocklens, const int *displacements,
                  Datatype oldtype, Datatype *newtype);
 extern int Type_lb(Datatype type, MPI_Aint * lb);
 extern int Type_size(Datatype type, int * size);
-extern int Type_struct(int count, int * blocklens, MPI_Aint * displacements,
+extern int Type_struct(int count, const int * blocklens, const MPI_Aint * displacements,
                 Datatype *oldtypes_ptr,     Datatype *newtype);
 extern int Type_ub(Datatype type, MPI_Aint * ub);
 extern int Type_vector(int count, int blocklen, int stride,


### PR DESCRIPTION
This PR introduces several updates to the mpi-serial library to
improve consistency and maintainability.

Changes:
* Align MPI function declarations with MPICH, including
  adjustments to const correctness and the use of arrays
  vs. pointers.
* Update corresponding function bodies to reflect the changes
  in declarations.
* Modify internal functions to ensure compatibility with
  updated MPI function signatures.
* Change buf in struct Req from int* to void* for better
  generality in handling user buffers.
* Remove the duplicate declaration of MPI_Get_library_version.